### PR TITLE
Initial MarkLogic EvaluatePlan implementation

### DIFF
--- a/core/src/main/scala/quasar/fs/impl.scala
+++ b/core/src/main/scala/quasar/fs/impl.scala
@@ -17,15 +17,18 @@
 package quasar.fs
 
 import quasar.Predef._
+import quasar.{LogicalPlan, PhaseResults}
 import quasar.fp.numeric._
 import quasar.fp.free._
 import quasar.Data
 import quasar.effect.{KeyValueStore, MonotonicSeq}
 
+import matryoshka.Fix
 import scalaz._, Scalaz._
 import scalaz.stream.Process
 
 object impl {
+  import FileSystemError._
 
   final case class ReadOpts(offset: Natural, limit: Option[Positive])
 
@@ -47,7 +50,7 @@ object impl {
 
       case ReadFile.Read(handle) =>
         (for {
-          cursor <- cursors.get(handle).toRight(FileSystemError.unknownReadHandle(handle))
+          cursor <- cursors.get(handle).toRight(unknownReadHandle(handle))
           result <- EitherT(read(cursor))
           (newCursor, data) = result
           _ <- cursors.put(handle, newCursor).liftM[FileSystemErrT]
@@ -80,7 +83,7 @@ object impl {
 
         case ReadFile.Read(handle) =>
           (for {
-            stream <- state.get(handle).toRight(FileSystemError.unknownReadHandle(handle))
+            stream <- state.get(handle).toRight(unknownReadHandle(handle))
             data   <- EitherT(lift(stream.unconsOption).into[S].flatMap {
                         case Some((value, streamTail)) =>
                           state.put(handle, streamTail).as(value.right[FileSystemError])
@@ -97,4 +100,70 @@ object impl {
           } yield ()).run.void
       }
     }
+
+  def queryFile[S[_], C](
+    execute: (Fix[LogicalPlan], AFile) => Free[S, (PhaseResults, FileSystemError \/ AFile)],
+    evaluate: Fix[LogicalPlan] => Free[S, (PhaseResults, FileSystemError \/ C)],
+    more: C => Free[S, FileSystemError \/ (C, Vector[Data])],
+    close: C => Free[S, Unit],
+    explain: Fix[LogicalPlan] => Free[S, (PhaseResults, FileSystemError \/ ExecutionPlan)],
+    listContents: ADir => Free[S, FileSystemError \/ Set[PathSegment]],
+    fileExists: AFile => Free[S, Boolean]
+  )(implicit
+    cursors: KeyValueStore.Ops[QueryFile.ResultHandle, C, S],
+    mseq:    MonotonicSeq.Ops[S]
+  ): QueryFile ~> Free[S, ?] =
+    new (QueryFile ~> Free[S, ?]) {
+      def apply[A](qf: QueryFile[A]) = qf match {
+        case QueryFile.ExecutePlan(lp, out) => execute(lp, out)
+        case QueryFile.Explain(lp)          => explain(lp)
+        case QueryFile.ListContents(dir)    => listContents(dir)
+        case QueryFile.FileExists(file)     => fileExists(file)
+
+        case QueryFile.EvaluatePlan(lp) =>
+          evaluate(lp) flatMap { case (phaseResults, orCursor) =>
+            val handle = for {
+              cursor <- EitherT.fromDisjunction[Free[S, ?]](orCursor)
+              id     <- mseq.next.liftM[FileSystemErrT]
+              h      =  QueryFile.ResultHandle(id)
+              _      <- cursors.put(h, cursor).liftM[FileSystemErrT]
+            } yield h
+
+            handle.run strengthL phaseResults
+          }
+
+        case QueryFile.More(h) =>
+          (for {
+            cursor <- cursors.get(h).toRight(unknownResultHandle(h))
+            result <- EitherT(more(cursor))
+            (nextCursor, data) = result
+            _      <- cursors.put(h, nextCursor).liftM[FileSystemErrT]
+          } yield data).run
+
+        case QueryFile.Close(h) =>
+          cursors.get(h)
+            .flatMapF(c => close(c) *> cursors.delete(h))
+            .orZero
+      }
+    }
+
+  def queryFileFromDataCursor[S[_], C](
+    execute: (Fix[LogicalPlan], AFile) => Free[S, (PhaseResults, FileSystemError \/ AFile)],
+    evaluate: Fix[LogicalPlan] => Free[S, (PhaseResults, FileSystemError \/ C)],
+    explain: Fix[LogicalPlan] => Free[S, (PhaseResults, FileSystemError \/ ExecutionPlan)],
+    listContents: ADir => Free[S, FileSystemError \/ Set[PathSegment]],
+    fileExists: AFile => Free[S, Boolean]
+  )(implicit
+    C:  DataCursor[Free[S, ?], C],
+    S0: KeyValueStore[QueryFile.ResultHandle, C, ?] :<: S,
+    S1: MonotonicSeq :<: S
+  ): QueryFile ~> Free[S, ?] =
+    queryFile[S, C](
+      execute,
+      evaluate,
+      c => C.nextChunk(c).map(_.right[FileSystemError].strengthL(c)),
+      c => C.close(c),
+      explain,
+      listContents,
+      fileExists)
 }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/fs/package.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/fs/package.scala
@@ -18,7 +18,7 @@ package quasar.physical.marklogic
 
 import quasar.Predef._
 import quasar.Data
-import quasar.effect.{KeyValueStore, MonotonicSeq, Read}
+import quasar.effect.{Failure, KeyValueStore, MonotonicSeq, Read}
 import quasar.fp._
 import quasar.fp.free._
 import quasar.fs._
@@ -28,31 +28,69 @@ import com.marklogic.client._
 import com.marklogic.xcc._
 import java.net.URI
 
-import scalaz._, Scalaz._
+import eu.timepit.refined.auto._
+import scalaz.{Failure => _, _}, Scalaz._
 import scalaz.concurrent.Task
 import scalaz.stream.Process
 
 package object fs {
+  import ReadFile.ReadHandle, WriteFile.WriteHandle, QueryFile.ResultHandle
+  import xcc.ChunkedResultSequence
+
   val FsType = FileSystemType("marklogic")
 
-  type Eff0[A] = Coproduct[
-                    KeyValueStore[ReadFile.ReadHandle, Process[Task, Vector[Data]], ?],
-                    KeyValueStore[WriteFile.WriteHandle, Unit, ?],
-                    A]
-  type Eff1[A] = Coproduct[MonotonicSeq, Eff0, A]
-  type Eff2[A] = Coproduct[Read[Client, ?], Eff1, A]
-  type Eff[A]  = Coproduct[Task, Eff2, A]
+  type XccCursor[A]  = Coproduct[Task, xcc.XccFailure, A]
+  type XccCursorM[A] = Free[XccCursor, A]
+
+  type MLReadHandles[A] = KeyValueStore[ReadHandle, Process[Task, Vector[Data]], A]
+  type MLWriteHandles[A] = KeyValueStore[WriteHandle, Unit, A]
+  type MLResultHandles[A] = KeyValueStore[ResultHandle, ChunkedResultSequence[XccCursor], A]
+
+  type Eff[A]  = Coproduct[Task, Eff0, A]
+  type Eff0[A] = Coproduct[ClientR, Eff1, A]
+  type Eff1[A] = Coproduct[MonotonicSeq, Eff2, A]
+  type Eff2[A] = Coproduct[MLReadHandles, Eff3, A]
+  type Eff3[A] = Coproduct[MLWriteHandles, Eff4, A]
+  type Eff4[A] = Coproduct[MLResultHandles, Eff5, A]
+  type Eff5[A] = Coproduct[xcc.SessionR, Eff6, A]
+  type Eff6[A] = Coproduct[xcc.XccFailure, XccCursorM, A]
 
   def inter(uri0: ConnectionUri): Task[(Eff ~> Task, Task[Unit])] = {
     val uri = new URI(uri0.value)
     val (user, password0) = uri.getUserInfo.span(_ ≠ ':')
     val password = password0.drop(1)
     def dbClient: DatabaseClient = DatabaseClientFactory.newClient(uri.getHost, uri.getPort, user, password, DatabaseClientFactory.Authentication.DIGEST)
-    val client = Client(dbClient, ContentSourceFactory.newContentSource(uri))
-    (KeyValueStore.impl.empty[WriteFile.WriteHandle, Unit]                      |@|
-     KeyValueStore.impl.empty[ReadFile.ReadHandle, Process[Task, Vector[Data]]] |@|
-     MonotonicSeq.fromZero                                                         )((a,b,c) => c :+: b :+: a).map(i =>
-       (reflNT[Task] :+: Read.constant[Task, Client](client) :+: i, Task.delay(dbClient.release)))
+    val csource = ContentSourceFactory.newContentSource(uri)
+    val client = Client(dbClient, csource)
+    val failErrs = Failure.toRuntimeError[Task, xcc.XccError]
+
+    // TODO: Define elsewhere, can probably make this another generic impl of Read
+    val newSession: xcc.SessionR ~> Task =
+      new (xcc.SessionR ~> Task) {
+        def apply[A](ra: Read[Session, A]) = ra match {
+          case Read.Ask(f) => Task.delay(f(csource.newSession))
+        }
+      }
+
+    (
+      KeyValueStore.impl.empty[WriteHandle, Unit]                              |@|
+      KeyValueStore.impl.empty[ReadHandle, Process[Task, Vector[Data]]]        |@|
+      KeyValueStore.impl.empty[ResultHandle, ChunkedResultSequence[XccCursor]] |@|
+      MonotonicSeq.fromZero
+    ) { (whandles, rhandles, qhandles, seq) =>
+      val toTask =
+        reflNT[Task]                        :+:
+        Read.constant[Task, Client](client) :+:
+        seq                                 :+:
+        rhandles                            :+:
+        whandles                            :+:
+        qhandles                            :+:
+        newSession                          :+:
+        failErrs                            :+:
+        foldMapNT(reflNT[Task] :+: failErrs)
+
+      (toTask, Task.delay(dbClient.release))
+    }
   }
 
   def definition[S[_]](implicit
@@ -64,7 +102,7 @@ package object fs {
         lift(inter(uri).map { case (run, release) =>
           FileSystemDef.DefinitionResult[Free[S, ?]](
             mapSNT(injectNT[Task, S] compose run) compose interpretFileSystem(
-              queryfile.interpret[Eff],
+              queryfile.interpret[Eff](100L),
               readfile.interpret[Eff],
               writefile.interpret[Eff],
               managefile.interpret[Eff]),

--- a/marklogic/src/main/scala/quasar/physical/marklogic/fs/queryFile.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/fs/queryFile.scala
@@ -17,53 +17,72 @@
 package quasar.physical.marklogic.fs
 
 import quasar.Predef._
+import quasar.LogicalPlan
+import quasar.PhaseResult
+import quasar.Planner.PlannerError
+import quasar.effect.MonotonicSeq
 import quasar.fs._
-import quasar.effect.Read
+import quasar.fs.impl.queryFileFromDataCursor
+import quasar.fp.numeric.Positive
 import quasar.physical.marklogic._
 import quasar.physical.marklogic.qscript._
-import quasar.Planner.PlannerError
+import quasar.physical.marklogic.xcc.{ChunkedResultSequence, SessionR, XccFailure}
 import quasar.qscript._
 
+import com.marklogic.xcc.RequestOptions
 import matryoshka._, Recursive.ops._
-import pathy.Path._
 import scalaz._, Scalaz._, concurrent._
 
 object queryfile {
   import QueryFile._
+  import FileSystemError._
   import MarkLogicPlanner._
 
   def interpret[S[_]](
-    implicit
-    S0: Read[Client, ?] :<: S,
-    S1: Task :<: S
-  ): QueryFile ~> Free[S, ?] = new (QueryFile ~> Free[S, ?]) {
-    def apply[A](qf: QueryFile[A]) = qf match {
-      case ExecutePlan(lp, out) => (
-          for {
-            qs     <- EitherT(convertToQScript(lp).point[Free[S, ?]])
-            _      =  println(s"queryfile interpret qs: $qs")
-            xquery <- EitherT(qs.cataM(Planner[QScriptTotal[Fix, ?], XQuery].plan).point[Free[S, ?]])
-            _      <- Client.execute(xquery, fileParent(out) </> dir(fileName(out).value)).liftM[EitherT[?[_], PlannerError, ?]]
-          } yield out
-        ).leftMap(FileSystemError.planningFailed(lp,_)).run.strengthL(Vector.empty)
+    resultsChunkSize: Positive
+  )(implicit
+    S0: SessionR :<: S,
+    S1: XccFailure :<: S,
+    S2: MLResultHandles :<: S,
+    S3: MonotonicSeq :<: S,
+    S4: Task :<: S,
+    S5: XccCursorM :<: S
+  ): QueryFile ~> Free[S, ?] = {
+    val session = xcc.session.Ops[S]
 
-      case EvaluatePlan(lp) =>
-        ???
-
-      case More(h) =>
-        ???
-
-      case Close(h) =>
-        ???
-
-      case Explain(lp) =>
-        ???
-
-      case ListContents(dir) =>
-        ???
-
-      case FileExists(file) =>
-        ???
+    val evalOpts = {
+      val ropts = new RequestOptions
+      ropts.setCacheResult(false)
+      ropts
     }
+
+    def planLP(lp: Fix[LogicalPlan]): PlannerError \/ XQuery =
+      convertToQScript(lp) >>= (_.cataM(Planner[QScriptTotal[Fix, ?], XQuery].plan))
+
+    def exec(lp: Fix[LogicalPlan], out: AFile) =
+      planLP(lp).fold(
+        err => (Vector.empty[PhaseResult], \/.left(planningFailed(lp, err))),
+        xqy => (Vector(PhaseResult.Detail("XQuery", xqy)), \/.right(out))
+      ).point[Free[S, ?]]
+
+    // TODO: PhaseResults
+    def eval(lp: Fix[LogicalPlan]) =
+      EitherT.fromDisjunction[Free[S, ?]](planLP(lp))
+        .leftMap(planningFailed(lp, _))
+        .flatMap(session.evaluateQuery(_, evalOpts).liftM[FileSystemErrT])
+        .map(new ChunkedResultSequence[XccCursor](resultsChunkSize, _))
+        .run
+        .strengthL(Vector.empty[PhaseResult])
+
+    // TODO: Eliminate duplication with exec
+    def explain(lp: Fix[LogicalPlan]) =
+      planLP(lp).fold(
+        err => (Vector.empty[PhaseResult], \/.left(planningFailed(lp, err))),
+        xqy => (Vector(PhaseResult.Detail("XQuery", xqy)), \/.right(ExecutionPlan(FsType, xqy)))
+      ).point[Free[S, ?]]
+
+    queryFileFromDataCursor[S, XccCursorM, ChunkedResultSequence[XccCursor]](exec, eval, explain,
+      dir  => Set[PathSegment]().point[FileSystemErrT[Free[S, ?], ?]].run,
+      file => false.point[Free[S, ?]])
   }
 }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/package.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/package.scala
@@ -14,25 +14,20 @@
  * limitations under the License.
  */
 
-package quasar.physical.marklogic
+package quasar.physical
 
-import quasar.effect.{Failure, Read}
+import quasar.Predef.String
+import quasar.effect.Read
 
-import com.marklogic.xcc.Session
 import scalaz.:<:
 
-package object xcc {
-  type SessionR[A] = Read[Session, A]
+package object marklogic {
+  type XQuery = String
 
-  object SessionR {
-    def Ops[S[_]](implicit S: SessionR :<: S) =
-      Read.Ops[Session, S]
-  }
+  type ClientR[A] = Read[Client, A]
 
-  type XccFailure[A] = Failure[XccError, A]
-
-  object XccFailure {
-    def Ops[S[_]](implicit S: XccFailure :<: S) =
-      Failure.Ops[XccError, S]
+  object ClientR {
+    def Ops[S[_]](implicit S: ClientR :<: S) =
+      Read.Ops[Client, S]
   }
 }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/DeadEndPlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/DeadEndPlanner.scala
@@ -14,25 +14,18 @@
  * limitations under the License.
  */
 
-package quasar.physical.marklogic
+package quasar.physical.marklogic.qscript
 
-import quasar.effect.{Failure, Read}
+import quasar.Predef._
+import quasar.Planner.PlannerError
+import quasar.physical.marklogic.XQuery
+import quasar.qscript._
 
-import com.marklogic.xcc.Session
-import scalaz.:<:
+import matryoshka._
+import scalaz._
 
-package object xcc {
-  type SessionR[A] = Read[Session, A]
-
-  object SessionR {
-    def Ops[S[_]](implicit S: SessionR :<: S) =
-      Read.Ops[Session, S]
-  }
-
-  type XccFailure[A] = Failure[XccError, A]
-
-  object XccFailure {
-    def Ops[S[_]](implicit S: XccFailure :<: S) =
-      Failure.Ops[XccError, S]
+private[qscript] final class DeadEndPlanner extends MarkLogicPlanner[Const[DeadEnd, ?]] {
+  val plan: AlgebraM[PlannerError \/ ?, Const[DeadEnd, ?], XQuery] = {
+    case Const(Root) => ???
   }
 }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/EquiJoinPlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/EquiJoinPlanner.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.marklogic.qscript
+
+import quasar.Predef.{Map => _, _}
+import quasar.Planner.PlannerError
+import quasar.physical.marklogic.XQuery
+import quasar.qscript._
+
+import matryoshka._
+import scalaz._
+
+private[qscript] final class EquiJoinPlanner[T[_[_]]] extends MarkLogicPlanner[EquiJoin[T, ?]] {
+  val plan: AlgebraM[PlannerError \/ ?, EquiJoin[T, ?], XQuery] = {
+    case EquiJoin(src, lBranch, rBranch, leftKey, rightKey, joinType, combineFunc) => ???
+  }
+}

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/Planner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/Planner.scala
@@ -16,110 +16,21 @@
 
 package quasar.physical.marklogic.qscript
 
-import quasar.Predef._
 import quasar.Planner.PlannerError
-import quasar.qscript, qscript._, MapFuncs._
 
 import matryoshka._
-import pathy.Path._
-import scalaz._, Scalaz._
+import scalaz._
+
+trait Planner[QS[_], A] {
+  def plan: AlgebraM[PlannerError \/ ?, QS, A]
+}
 
 object Planner {
+  def apply[QS[_], A](implicit ev: Planner[QS, A]): Planner[QS, A] = ev
 
-  def mapFunc[T[_[_]]]: Algebra[MapFunc[T, ?], String] = {
-    case v @ ToString(a1) => ???
-    case v => s" ???(MapFunc - $v)??? "
-  }
-
-  // TODO:
-  //   why is hylo necessary here over just cata?
-  //   why is hylo defined over free but not cata?
-  //   what is the intuition for CoEnv.freeIso?
-  // def freeCata[F[_]: Traverse, E, A](free: Free[F, E])(φ: Algebra[CoEnv[E, F, ?], A]) =
-  //   free.hylo(φ, CoEnv.freeIso[E, F].reverseGet)
-
-  // def getSqlFn[T[_[_]]: Recursive]: FreeMap[T] => String = freeMap =>
-  //   freeCata(freeMap)(interpret(κ("defaultname"), javascript))
-
-  type MarkLogicPlanner[QS[_]] = Planner[QS, String]
-
-  trait Planner[QS[_], A] {
-    def plan: AlgebraM[PlannerError \/ ?, QS, A]
-  }
-  object Planner {
-
-    def apply[QS[_],A](implicit ev: Planner[QS,A]): Planner[QS,A] = ev
-
-    implicit def coproduct[A, F[_]: Planner[?[_], A], G[_]: Planner[?[_], A]]: Planner[Coproduct[F, G, ?], A] =
-      new Planner[Coproduct[F, G, ?], A] {
-        def plan: AlgebraM[PlannerError \/ ?, Coproduct[F, G, ?], A] =
-          _.run.fold(Planner[F,A].plan, Planner[G,A].plan)
-      }
-  }
-
-  implicit def qscriptCore[T[_[_]]]: MarkLogicPlanner[QScriptCore[T, ?]] =
-    new Planner[QScriptCore[T, ?], String] {
-      val plan: AlgebraM[PlannerError \/ ?, QScriptCore[T, ?], String] = {
-        case qscript.Map(src, f)                           => ???
-        case qscript.Reduce(src, bucket, reducers, repair) => ???
-        case qscript.Sort(src, bucket, order)              => ???
-        case qscript.Filter(src, f)                        => s"cts:and-query(($src, $f))".right
-        case qscript.Take(src, from, count)                =>
-          def from0 = ""
-          def count0 = ""
-          s"fn:subsequence($src, $from0, $count0)".right
-        case qscript.Drop(src, from, count)                =>
-          def from0 = ""
-          def count0 = ""
-          s"(fn:subsequence($src, 1, $from0), fn:subsequence($src, $from0 + $count0))".right
-      }
+  implicit def coproduct[A, F[_], G[_]](implicit F: Planner[F, A], G: Planner[G, A]): Planner[Coproduct[F, G, ?], A] =
+    new Planner[Coproduct[F, G, ?], A] {
+      def plan: AlgebraM[PlannerError \/ ?, Coproduct[F, G, ?], A] =
+        _.run.fold(F.plan, G.plan)
     }
-
-  implicit def sourcedPathable[T[_[_]]]: MarkLogicPlanner[SourcedPathable[T, ?]] =
-    new Planner[SourcedPathable[T, ?], String] {
-      val plan: AlgebraM[PlannerError \/ ?, SourcedPathable[T, ?], String] = {
-        case LeftShift(src, struct, repair) => ???
-        case Union(src, lBranch, rBranch) => ???
-      }
-    }
-
-  implicit def constDeadEnd: MarkLogicPlanner[Const[DeadEnd, ?]] =
-    new MarkLogicPlanner[Const[DeadEnd, ?]] {
-      def plan: AlgebraM[PlannerError \/ ?, Const[DeadEnd, ?], String] = {
-        case Const(Root) => ??? //" null ".right
-      }
-    }
-
-  implicit def constRead: MarkLogicPlanner[Const[Read, ?]] =
-    new MarkLogicPlanner[Const[Read, ?]] {
-      def plan: AlgebraM[PlannerError \/ ?, Const[Read, ?], String] = {
-        case Const(Read(absFile)) =>
-          val asDir = fileParent(absFile) </> dir(fileName(absFile).value)
-          val dirRepr = posixCodec.printPath(asDir)
-          s"""cts:directory-query("$dirRepr","1")""".right
-      }
-    }
-
-  implicit def projectBucket[T[_[_]]]: MarkLogicPlanner[ProjectBucket[T, ?]] =
-    new MarkLogicPlanner[ProjectBucket[T, ?]] {
-      def plan: AlgebraM[PlannerError \/ ?, ProjectBucket[T, ?], String] = {
-        case BucketField(src, value, name)  => ???
-        case BucketIndex(src, value, index) => ???
-      }
-    }
-
-  implicit def thetajoin[T[_[_]]]: MarkLogicPlanner[ThetaJoin[T, ?]] =
-    new MarkLogicPlanner[ThetaJoin[T, ?]] {
-      def plan: AlgebraM[PlannerError \/ ?, ThetaJoin[T, ?], String] = {
-        case ThetaJoin(src, lBranch, rBranch, on, f, combine) => ???
-      }
-    }
-
-  implicit def equiJoin[T[_[_]]]: MarkLogicPlanner[EquiJoin[T, ?]] =
-    new MarkLogicPlanner[EquiJoin[T, ?]] {
-      def plan: AlgebraM[PlannerError \/ ?, EquiJoin[T, ?], String] = {
-        case EquiJoin(src, lBranch, rBranch, leftKey, rightKey, joinType, combineFunc) => ???
-      }
-    }
-
 }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/ProjectBucketPlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/ProjectBucketPlanner.scala
@@ -14,25 +14,19 @@
  * limitations under the License.
  */
 
-package quasar.physical.marklogic
+package quasar.physical.marklogic.qscript
 
-import quasar.effect.{Failure, Read}
+import quasar.Predef.{Map => _, _}
+import quasar.Planner.PlannerError
+import quasar.physical.marklogic.XQuery
+import quasar.qscript._
 
-import com.marklogic.xcc.Session
-import scalaz.:<:
+import matryoshka._
+import scalaz._
 
-package object xcc {
-  type SessionR[A] = Read[Session, A]
-
-  object SessionR {
-    def Ops[S[_]](implicit S: SessionR :<: S) =
-      Read.Ops[Session, S]
-  }
-
-  type XccFailure[A] = Failure[XccError, A]
-
-  object XccFailure {
-    def Ops[S[_]](implicit S: XccFailure :<: S) =
-      Failure.Ops[XccError, S]
+private[qscript] final class ProjectBucketPlanner[T[_[_]]] extends MarkLogicPlanner[ProjectBucket[T, ?]] {
+  val plan: AlgebraM[PlannerError \/ ?, ProjectBucket[T, ?], XQuery] = {
+    case BucketField(src, value, name)  => ???
+    case BucketIndex(src, value, index) => ???
   }
 }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/QScriptCorePlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/QScriptCorePlanner.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.marklogic.qscript
+
+import quasar.Predef.{Map => _, _}
+import quasar.Planner.PlannerError
+import quasar.physical.marklogic.XQuery
+import quasar.qscript._
+
+import matryoshka._
+import scalaz._, Scalaz._
+
+private[qscript] final class QScriptCorePlanner[T[_[_]]] extends MarkLogicPlanner[QScriptCore[T, ?]] {
+  val plan: AlgebraM[PlannerError \/ ?, QScriptCore[T, ?], XQuery] = {
+    case Map(src, f)                           => ???
+    case Reduce(src, bucket, reducers, repair) => ???
+    case Sort(src, bucket, order)              => ???
+    case Filter(src, f)                        => s"cts:and-query(($src, $f))".right
+    case Take(src, from, count)                =>
+      def from0 = ""
+      def count0 = ""
+      s"fn:subsequence($src, $from0, $count0)".right
+    case Drop(src, from, count)                =>
+      def from0 = ""
+      def count0 = ""
+      s"(fn:subsequence($src, 1, $from0), fn:subsequence($src, $from0 + $count0))".right
+  }
+}

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/SourcePathablePlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/SourcePathablePlanner.scala
@@ -14,25 +14,19 @@
  * limitations under the License.
  */
 
-package quasar.physical.marklogic
+package quasar.physical.marklogic.qscript
 
-import quasar.effect.{Failure, Read}
+import quasar.Predef._
+import quasar.Planner.PlannerError
+import quasar.physical.marklogic.XQuery
+import quasar.qscript._
 
-import com.marklogic.xcc.Session
-import scalaz.:<:
+import matryoshka._
+import scalaz._
 
-package object xcc {
-  type SessionR[A] = Read[Session, A]
-
-  object SessionR {
-    def Ops[S[_]](implicit S: SessionR :<: S) =
-      Read.Ops[Session, S]
-  }
-
-  type XccFailure[A] = Failure[XccError, A]
-
-  object XccFailure {
-    def Ops[S[_]](implicit S: XccFailure :<: S) =
-      Failure.Ops[XccError, S]
+private[qscript] final class SourcedPathablePlanner[T[_[_]]] extends MarkLogicPlanner[SourcedPathable[T, ?]] {
+  val plan: AlgebraM[PlannerError \/ ?, SourcedPathable[T, ?], XQuery] = {
+    case LeftShift(src, struct, repair) => ???
+    case Union(src, lBranch, rBranch) => ???
   }
 }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/ThetaJoinPlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/ThetaJoinPlanner.scala
@@ -14,25 +14,18 @@
  * limitations under the License.
  */
 
-package quasar.physical.marklogic
+package quasar.physical.marklogic.qscript
 
-import quasar.effect.{Failure, Read}
+import quasar.Predef.{Map => _, _}
+import quasar.Planner.PlannerError
+import quasar.physical.marklogic.XQuery
+import quasar.qscript._
 
-import com.marklogic.xcc.Session
-import scalaz.:<:
+import matryoshka._
+import scalaz._
 
-package object xcc {
-  type SessionR[A] = Read[Session, A]
-
-  object SessionR {
-    def Ops[S[_]](implicit S: SessionR :<: S) =
-      Read.Ops[Session, S]
-  }
-
-  type XccFailure[A] = Failure[XccError, A]
-
-  object XccFailure {
-    def Ops[S[_]](implicit S: XccFailure :<: S) =
-      Failure.Ops[XccError, S]
+private[qscript] final class ThetaJoinPlanner[T[_[_]]] extends MarkLogicPlanner[ThetaJoin[T, ?]] {
+  val plan: AlgebraM[PlannerError \/ ?, ThetaJoin[T, ?], XQuery] = {
+    case ThetaJoin(src, lBranch, rBranch, on, f, combine) => ???
   }
 }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/mapFuncXQuery.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/mapFuncXQuery.scala
@@ -14,25 +14,17 @@
  * limitations under the License.
  */
 
-package quasar.physical.marklogic
+package quasar.physical.marklogic.qscript
 
-import quasar.effect.{Failure, Read}
+import quasar.Predef._
+import quasar.physical.marklogic.XQuery
+import quasar.qscript.{MapFunc, MapFuncs}, MapFuncs._
 
-import com.marklogic.xcc.Session
-import scalaz.:<:
+import matryoshka.Algebra
 
-package object xcc {
-  type SessionR[A] = Read[Session, A]
-
-  object SessionR {
-    def Ops[S[_]](implicit S: SessionR :<: S) =
-      Read.Ops[Session, S]
-  }
-
-  type XccFailure[A] = Failure[XccError, A]
-
-  object XccFailure {
-    def Ops[S[_]](implicit S: XccFailure :<: S) =
-      Failure.Ops[XccError, S]
+object mapFuncXQuery {
+  def apply[T[_[_]]]: Algebra[MapFunc[T, ?], XQuery] = {
+    case v @ ToString(a1) => ???
+    case v => s" ???(MapFunc - $v)??? "
   }
 }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/package.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/package.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.marklogic
+
+import quasar.qscript._
+
+import scalaz.Const
+
+package object qscript {
+  type MarkLogicPlanner[QS[_]] = Planner[QS, XQuery]
+
+  object MarkLogicPlanner {
+    implicit def qScriptCore[T[_[_]]]: MarkLogicPlanner[QScriptCore[T, ?]] =
+      new QScriptCorePlanner[T]
+
+    implicit def sourcedPathable[T[_[_]]]: MarkLogicPlanner[SourcedPathable[T, ?]] =
+      new SourcedPathablePlanner[T]
+
+    implicit def constDeadEnd: MarkLogicPlanner[Const[DeadEnd, ?]] =
+      new DeadEndPlanner
+
+    implicit def constRead: MarkLogicPlanner[Const[Read, ?]] =
+      new ReadPlanner
+
+    implicit def projectBucket[T[_[_]]]: MarkLogicPlanner[ProjectBucket[T, ?]] =
+      new ProjectBucketPlanner[T]
+
+    implicit def thetajoin[T[_[_]]]: MarkLogicPlanner[ThetaJoin[T, ?]] =
+      new ThetaJoinPlanner[T]
+
+    implicit def equiJoin[T[_[_]]]: MarkLogicPlanner[EquiJoin[T, ?]] =
+      new EquiJoinPlanner[T]
+  }
+}

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xcc/ChunkedResultSequence.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xcc/ChunkedResultSequence.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.marklogic.xcc
+
+import quasar.Predef._
+import quasar.Data
+import quasar.fp.numeric.Positive
+import quasar.fs.DataCursor
+
+import com.marklogic.xcc.ResultSequence
+import com.marklogic.xcc.types.XdmItem
+import scalaz.syntax.functor._
+import scalaz.std.option._
+import scalaz.stream.Process
+import scalaz.concurrent.Task
+
+final class ChunkedResultSequence(val chunkSize: Positive, rs: ResultSequence) {
+  val close: Task[Executed] =
+    Task.delay(rs.close()).as(Executed.executed)
+
+  val nextChunk: Task[Vector[XdmItem]] =
+    Process.unfoldEval(())(_ => next.map(_ strengthR (())))
+      .take(chunkSize.get.toInt)
+      .runLog
+
+  // TODO: What kind of errors can happen when cache()-ing an item?
+  private val next: Task[Option[XdmItem]] =
+    Task delay {
+      if (rs.hasNext) {
+        val ritem = rs.next
+        ritem.cache()
+        Some(ritem.getItem)
+      } else None
+    }
+}
+
+object ChunkedResultSequence {
+  implicit val dataCursor: DataCursor[Task, ChunkedResultSequence] =
+    new DataCursor[Task, ChunkedResultSequence] {
+      def close(crs: ChunkedResultSequence) =
+        crs.close.void
+
+      // TODO: Better to just handle this in the stream?
+      def nextChunk(crs: ChunkedResultSequence) =
+        crs.nextChunk.map(_.foldLeft(Vector[Data]())((ds, x) =>
+          xdmitem.toData(x).fold(ds)(ds :+ _)))
+    }
+}

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xcc/Executed.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xcc/Executed.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.marklogic.xcc
+
+import quasar.Predef.Unit
+import quasar.SKI.κ
+
+import monocle.Iso
+import scalaz.{Show, Order}
+import scalaz.std.anyVal._
+
+/** A content-free value indicating an operation was executed but does not produce
+  * any results.
+  */
+sealed abstract class Executed
+
+object Executed {
+  val executed: Executed = new Executed {}
+
+  val isoUnit: Iso[Executed, Unit] =
+    Iso[Executed, Unit](κ(()))(κ(executed))
+
+  implicit val order: Order[Executed] =
+    Order.orderBy(isoUnit.get)
+
+  implicit val show: Show[Executed] =
+    Show.shows(κ("Executed"))
+}

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xcc/XccError.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xcc/XccError.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.marklogic.xcc
+
+import quasar.Predef._
+import quasar.SKI.κ
+
+import com.marklogic.xcc.exceptions.RequestException
+import monocle.Prism
+import scalaz.{Equal, Show}
+
+sealed abstract class XccError
+
+object XccError {
+  final case class RequestError(cause: RequestException) extends XccError
+  case object SessionIsClosed extends XccError
+
+  val requestError: Prism[XccError, RequestException] =
+    Prism.partial[XccError, RequestException] {
+      case RequestError(c) => c
+    } (RequestError)
+
+  val sessionIsClosed: Prism[XccError, Unit] =
+    Prism.partial[XccError, Unit] {
+      case SessionIsClosed => ()
+    } (κ(SessionIsClosed))
+
+  implicit val equal: Equal[XccError] =
+    Equal.equalA
+
+  implicit val show: Show[XccError] =
+    Show.shows {
+      case SessionIsClosed  => "Session is closed."
+      case RequestError(ex) => s"RequestError: ${ex.getMessage}"
+    }
+}

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xcc/data.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xcc/data.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.marklogic.xcc
+
+import quasar.Predef._
+import quasar.Data
+
+import jawn._
+
+object data {
+  object JsonParser extends SupportParser[Data] {
+    implicit val facade: Facade[Data] =
+      new SimpleFacade[Data] {
+        def jarray(arr: List[Data]) = Data.Arr(arr)
+        // TODO: Should `ListMap` really be in the interface, or just used as impl?
+        def jobject(obj: Map[String, Data]) = Data.Obj(ListMap(obj.toList: _*))
+        def jnull() = Data.Null
+        def jfalse() = Data.False
+        def jtrue() = Data.True
+        def jnum(n: String) = Data.Dec(BigDecimal(n))
+        def jint(n: String) = Data.Int(BigInt(n))
+        def jstring(s: String) = Data.Str(s)
+      }
+  }
+}

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xcc/package.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xcc/package.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.marklogic
+
+import quasar.effect.{Failure, Read}
+import quasar.Predef._
+
+import com.marklogic.xcc.Session
+
+package object xcc {
+  type XQuery = String
+  type SessionR[A] = Read[Session, A]
+  type XccFailure[A] = Failure[XccError, A]
+}

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xcc/package.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xcc/package.scala
@@ -20,9 +20,22 @@ import quasar.effect.{Failure, Read}
 import quasar.Predef._
 
 import com.marklogic.xcc.Session
+import scalaz.:<:
 
 package object xcc {
   type XQuery = String
+
   type SessionR[A] = Read[Session, A]
+
+  object SessionR {
+    def Ops[S[_]](implicit S: SessionR :<: S) =
+      Read.Ops[Session, S]
+  }
+
   type XccFailure[A] = Failure[XccError, A]
+
+  object XccFailure {
+    def Ops[S[_]](implicit S: XccFailure :<: S) =
+      Failure.Ops[XccError, S]
+  }
 }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xcc/session.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xcc/session.scala
@@ -60,5 +60,10 @@ object session {
     private def captured[A](f: XccSession => A): F[Task[A]] =
       session.map(s => Task.delay(f(s)))
   }
+
+  object Ops {
+    def apply[S[_]](implicit S0: SessionR :<: S) =
+      new Ops[S]
+  }
 }
 

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xcc/session.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xcc/session.scala
@@ -28,7 +28,7 @@ import scalaz.{Failure => _, _}, Scalaz._
 import scalaz.concurrent.Task
 
 object session {
-  final class Ops[S[_], A](implicit S0: SessionR :<: S) {
+  final class Ops[S[_]](implicit S0: SessionR :<: S) {
     import XccError._, Executed._
 
     type F[A] = Free[S, A]

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xcc/session.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xcc/session.scala
@@ -18,6 +18,7 @@ package quasar.physical.marklogic.xcc
 
 import quasar.Predef._
 import quasar.fp.free.lift
+import quasar.physical.marklogic.XQuery
 
 import java.lang.IllegalStateException
 

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xcc/session.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xcc/session.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.marklogic.xcc
+
+import quasar.Predef._
+import quasar.effect.{Failure, Read}
+import quasar.fp.free.lift
+
+import java.lang.IllegalStateException
+
+import com.marklogic.xcc.{Session => XccSession, _}
+import com.marklogic.xcc.exceptions.RequestException
+import scalaz.{Failure => _, _}, Scalaz._
+import scalaz.concurrent.Task
+
+object session {
+  final class Ops[S[_], A](implicit S0: SessionR :<: S) {
+    import XccError._, Executed._
+
+    type F[A] = Free[S, A]
+
+    def close(implicit S1: Task :<: S): F[Executed] =
+      captured(_.close).flatMap(lift(_).into[S]).as(executed)
+
+    def defaultEvaluateQuery(query: XQuery)(implicit S1: Task :<: S, S2: XccFailure :<: S): F[ResultSequence] =
+      evaluateQuery(query, new RequestOptions())
+
+    def evaluateQuery(query: XQuery, options: RequestOptions)(implicit S1: Task :<: S, S2: XccFailure :<: S): F[ResultSequence] =
+      liftT(s => s.submitRequest(s.newAdhocQuery(query, options)))
+
+    def session: F[XccSession] =
+      Read.Ops[XccSession, S].ask
+
+    ////
+
+    private def liftT[A](f: XccSession => A)(implicit S1: Task :<: S, S2: XccFailure :<: S): F[A] =
+      session flatMap { s =>
+        val handled = Task.delay(f(s).right[XccError]) handleWith {
+          case ise: IllegalStateException => sessionIsClosed().left[A].point[Task]
+          case rex: RequestException      => requestError(rex).left[A].point[Task]
+        }
+
+        Failure.Ops[XccError, S].unattempt(lift(handled).into[S])
+      }
+
+    private def captured[A](f: XccSession => A): F[Task[A]] =
+      session.map(s => Task.delay(f(s)))
+  }
+}
+

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xcc/session.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xcc/session.scala
@@ -17,14 +17,13 @@
 package quasar.physical.marklogic.xcc
 
 import quasar.Predef._
-import quasar.effect.{Failure, Read}
 import quasar.fp.free.lift
 
 import java.lang.IllegalStateException
 
 import com.marklogic.xcc.{Session => XccSession, _}
 import com.marklogic.xcc.exceptions.RequestException
-import scalaz.{Failure => _, _}, Scalaz._
+import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 
 object session {
@@ -43,7 +42,7 @@ object session {
       liftT(s => s.submitRequest(s.newAdhocQuery(query, options)))
 
     def session: F[XccSession] =
-      Read.Ops[XccSession, S].ask
+      SessionR.Ops[S].ask
 
     ////
 
@@ -54,7 +53,7 @@ object session {
           case rex: RequestException      => requestError(rex).left[A].point[Task]
         }
 
-        Failure.Ops[XccError, S].unattempt(lift(handled).into[S])
+        XccFailure.Ops[S].unattempt(lift(handled).into[S])
       }
 
     private def captured[A](f: XccSession => A): F[Task[A]] =

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xcc/xdmitem.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xcc/xdmitem.scala
@@ -20,10 +20,47 @@ import quasar.Predef._
 import quasar.Data
 
 import com.marklogic.xcc.types._
+import scalaz._
 
 object xdmitem {
+  // TODO: What sort of error handling to we want?
   val toData: XdmItem => Option[Data] = {
-    case jitem: JsonItem => data.JsonParser.parseFromString(jitem.asString).toOption
-    case _               => None
+    case item: CtsBox                   => None
+    case item: CtsCircle                => None
+    case item: CtsPoint                 => None
+    case item: CtsPolygon               => None
+    // TODO: What is the difference between JSArray/Object and their *Node variants?
+    case item: JSArray                  => None
+    case item: JSObject                 => None
+    case item: JsonItem                 => data.JsonParser.parseFromString(item.asString).toOption
+    case item: XdmAttribute             => None
+    // TODO: Inefficient for large data as it must be buffered into memory
+    case item: XdmBinary                => Some(Data.Binary(ImmutableArray.fromArray(item.asBinaryData)))
+    case item: XdmComment               => None
+    case item: XdmDocument              => None
+    case item: XdmElement               => None
+    case item: XdmProcessingInstruction => None
+    case item: XdmText                  => None
+    case item: XSAnyURI                 => None
+    case item: XSBase64Binary           => Some(Data.Binary(ImmutableArray.fromArray(item.asBinaryData)))
+    case item: XSBoolean                => Some(Data.Bool(item.asPrimitiveBoolean))
+    case item: XSDate                   => None
+    case item: XSDateTime               => None
+    case item: XSDecimal                => Some(Data.Dec(item.asBigDecimal))
+    case item: XSDouble                 => Some(Data.Dec(item.asBigDecimal))
+    case item: XSDuration               => None
+    case item: XSFloat                  => Some(Data.Dec(item.asBigDecimal))
+    case item: XSGDay                   => None
+    case item: XSGMonth                 => None
+    case item: XSGMonthDay              => None
+    case item: XSGYear                  => None
+    case item: XSGYearMonth             => None
+    case item: XSHexBinary              => Some(Data.Binary(ImmutableArray.fromArray(item.asBinaryData)))
+    case item: XSInteger                => Some(Data.Int(item.asBigInteger))
+    case item: XSQName                  => None
+    case item: XSString                 => Some(Data.Str(item.asString))
+    case item: XSTime                   => None
+    case item: XSUntypedAtomic          => None
+    case _                              => None
   }
 }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xcc/xdmitem.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xcc/xdmitem.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.marklogic.xcc
+
+import quasar.Predef._
+import quasar.Data
+
+import com.marklogic.xcc.types._
+
+object xdmitem {
+  val toData: XdmItem => Option[Data] = {
+    case jitem: JsonItem => data.JsonParser.parseFromString(jitem.asString).toOption
+    case _               => None
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,6 +7,7 @@ import sbt._, Keys._
 object Dependencies {
   private val argonautVersion   = "6.2-M3"
   private val http4sVersion     = "0.14.1a"
+  private val jawnVersion       = "0.8.4"
   private val monocleVersion    = "1.2.2"
   private val nettyVersion      = "4.1.3.Final"
   private val pathyVersion      = "0.2.1"
@@ -61,8 +62,9 @@ object Dependencies {
   def marklogic = Seq(
     "com.marklogic"  %  "java-client-api"   % "3.0.5",
     "com.marklogic"  %  "marklogic-xcc"     % "8.0.5",
-    "org.http4s"     %% "jawn-streamz"      % "0.8.1",
-    "org.spire-math" %% "jawn-argonaut"     % "0.8.4"
+    "org.spire-math" %% "jawn-argonaut"     % jawnVersion,
+    "org.spire-math" %% "jawn-parser"       % jawnVersion,
+    "org.http4s"     %% "jawn-streamz"      % "0.8.1"
   )
   def web = Seq(
     "ch.qos.logback"  % "logback-classic"     %      "1.1.7",


### PR DESCRIPTION
Introduces an `xcc` package with the beginnings of effects for that library, also stubs out an `XdmItem => Option[Data]` conversion (haven't gotten around to the other direction yet).

Uses these to implement `QueryFile.EvaluatePlan` to stream `XQuery` results back from MarkLogic.

Everything is compiling, but I haven't tried running the query regression tests yet.
